### PR TITLE
Fix SetProxy to pass password instead of username twice for .Net Fram…

### DIFF
--- a/WmiLight.Native/WmiLight.Native.rc
+++ b/WmiLight.Native/WmiLight.Native.rc
@@ -43,8 +43,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 6,16,0,0
- PRODUCTVERSION 6,16,0,0
+ FILEVERSION 6,17,0,0
+ PRODUCTVERSION 6,17,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -70,12 +70,12 @@ BEGIN
     VALUE "FileDescription", "The native part of the WmiLight lib."
 #endif
 
-            VALUE "FileVersion", "6.16.0.0"
+            VALUE "FileVersion", "6.17.0.0"
             VALUE "InternalName", "WmiLight.Native"
             VALUE "LegalCopyright", "Copyright 2025 Martin Kuschnik"
             VALUE "OriginalFilename", "WmiLight.Native.dll"
             VALUE "ProductName", "WmiLight"
-            VALUE "ProductVersion", "6.16.0.0"
+            VALUE "ProductVersion", "6.17.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/WmiLight/Internal/NativeMethods.cs
+++ b/WmiLight/Internal/NativeMethods.cs
@@ -302,9 +302,9 @@
             AuthenticationLevel authenticationLevel)
         {
             if (Environment.Is64BitProcess)
-                return x64.SetProxy(pIUnknown, username, username, authority, impersonationLevel, authenticationLevel);
+                return x64.SetProxy(pIUnknown, username, password, authority, impersonationLevel, authenticationLevel);
             else
-                return x86.SetProxy(pIUnknown, username, username, authority, impersonationLevel, authenticationLevel);
+                return x86.SetProxy(pIUnknown, username, password, authority, impersonationLevel, authenticationLevel);
         }
         public static HResult ExecQuery(
             IntPtr pWbemServices,

--- a/WmiLight/WmiLight.csproj
+++ b/WmiLight/WmiLight.csproj
@@ -23,7 +23,7 @@
 	</Target>
 	<PropertyGroup />
 	<PropertyGroup>
-		<Version>6.16.0</Version>
+		<Version>6.17.0</Version>
 		<PackageId>WmiLight</PackageId>
 		<Authors>Martin Kuschnik</Authors>
 		<Company>Martin Kuschnik</Company>
@@ -41,6 +41,7 @@
 
 		<!-- Workaround for https://github.com/dotnet/sdk/issues/43016. -->
 		<_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage>true</_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage>
+		<FileVersion>6.17.0</FileVersion>
 		
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
…ework implementation

Corrected SetProxy calls to use the password parameter rather than passing the username twice for both x86 and x64 processes. This ensures proper authentication credentials are used.

see #59 