### PR TITLE
Fix:  Correct EnablePackageEncryption to AuthenticationLevel mapping

### DIFF
--- a/WmiLight.Native/WmiLight.Native.rc
+++ b/WmiLight.Native/WmiLight.Native.rc
@@ -43,8 +43,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 6,17,0,0
- PRODUCTVERSION 6,17,0,0
+ FILEVERSION 6,18,0,0
+ PRODUCTVERSION 6,18,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -70,12 +70,12 @@ BEGIN
     VALUE "FileDescription", "The native part of the WmiLight lib."
 #endif
 
-            VALUE "FileVersion", "6.17.0.0"
+            VALUE "FileVersion", "6.18.0.0"
             VALUE "InternalName", "WmiLight.Native"
             VALUE "LegalCopyright", "Copyright 2025 Martin Kuschnik"
             VALUE "OriginalFilename", "WmiLight.Native.dll"
             VALUE "ProductName", "WmiLight"
-            VALUE "ProductVersion", "6.17.0.0"
+            VALUE "ProductVersion", "6.18.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/WmiLight/WmiConnection.cs
+++ b/WmiLight/WmiConnection.cs
@@ -295,7 +295,7 @@
                     {
                         if (!this.isConnected)
                         {
-                            AuthenticationLevel authLevel = this.options.EnablePackageEncryption ? AuthenticationLevel.PacketIntegrity : AuthenticationLevel.PacketPrivacy;
+                            AuthenticationLevel authLevel = this.options.EnablePackageEncryption ? AuthenticationLevel.PacketPrivacy : AuthenticationLevel.PacketIntegrity;
 
                             if (this.IsRemote)
                             {

--- a/WmiLight/WmiLight.csproj
+++ b/WmiLight/WmiLight.csproj
@@ -23,7 +23,7 @@
 	</Target>
 	<PropertyGroup />
 	<PropertyGroup>
-		<Version>6.17.0</Version>
+		<Version>6.18.0</Version>
 		<PackageId>WmiLight</PackageId>
 		<Authors>Martin Kuschnik</Authors>
 		<Company>Martin Kuschnik</Company>
@@ -41,7 +41,7 @@
 
 		<!-- Workaround for https://github.com/dotnet/sdk/issues/43016. -->
 		<_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage>true</_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage>
-		<FileVersion>6.17.0</FileVersion>
+		<FileVersion>6.18.0</FileVersion>
 		
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
The assignment of AuthenticationLevel based on EnablePackageEncryption was reversed, causing encrypted connections to use PacketIntegrity (no encryption) and unencrypted connections to use PacketPrivacy (with encryption).

Fixed mapping:
- EnablePackageEncryption = true  → PacketPrivacy (with encryption)
- EnablePackageEncryption = false → PacketIntegrity (no encryption)

Related to #61