### PR TITLE
Add support for CimType.Reference[] and related unit test

### DIFF
--- a/WmiLight.UnitTests/Msvm_VirtualSystemManagementService.cs
+++ b/WmiLight.UnitTests/Msvm_VirtualSystemManagementService.cs
@@ -1,0 +1,47 @@
+﻿namespace WmiLight.UnitTests
+{
+    [TestClass]
+    public class Msvm_VirtualSystemManagementService
+    {
+        [TestMethod]
+        public void GetSummaryInformation_SettingData_ReferenceArray_Can_Be_Read_Back()
+        {
+            const string WmiNamespace = @"root\virtualization\v2";
+            const string WmiClassName = "Msvm_VirtualSystemManagementService";
+            const string MethodName = "GetSummaryInformation";
+            const string ParameterName = "SettingData";
+
+            using WmiConnection connection = new(WmiNamespace);
+
+            WmiObject instance;
+
+            try
+            {
+                instance = WmiHelper.GetFirstWmiLightObjects(connection, WmiClassName);
+            }
+            catch
+            {
+                Assert.Inconclusive("Hyper-V namespace or class not available.");
+                return;
+            }
+
+            using (instance)
+            using (WmiMethod method = instance.GetMethod(MethodName))
+            using (WmiMethodParameters inParams = method.CreateInParameters())
+            {
+                string[] testPaths = [@"\\server\root\virtualization\v2:Path1", @"\\server\root\virtualization\v2:Path2"];
+                inParams.SetPropertyValue(ParameterName, testPaths);
+
+                // Before the fix, this throws NotSupportedException:
+                // "CimType 'Reference[]' currently not supported."
+                object nonGenericValue = inParams.GetPropertyValue(ParameterName);
+
+                Assert.IsInstanceOfType<string[]>(nonGenericValue, "Non-generic GetPropertyValue should return string[].");
+
+                string[] genericValue = inParams.GetPropertyValue<string[]>(ParameterName);
+
+                CollectionAssert.AreEqual(testPaths, genericValue, "Round-tripped Reference[] values should match.");
+            }
+        }
+    }
+}

--- a/WmiLight/Wbem/WbemClassObject.cs
+++ b/WmiLight/Wbem/WbemClassObject.cs
@@ -391,6 +391,9 @@ namespace WmiLight.Wbem
                     case CimType.Object:
                         return VariantToArray<WbemClassObject>(ref value, typeWithoutArrayFlag);
 
+                    case CimType.Reference:
+                        return VariantToArray<string>(ref value, typeWithoutArrayFlag);
+
                     default:
                         throw new NotSupportedException($"CimType '{typeWithoutArrayFlag}[]' currently not supported.");
                 }


### PR DESCRIPTION
Added handling for CimType.Reference[] in WbemClassObject to allow reading arrays of WMI references as string[]. Introduced a unit test for Msvm_VirtualSystemManagementService to verify correct round-tripping of Reference[] properties, ensuring NotSupportedException is no longer thrown.

Fixes #78